### PR TITLE
 fix weixin backend error

### DIFF
--- a/social_core/backends/weixin.py
+++ b/social_core/backends/weixin.py
@@ -13,7 +13,7 @@ from ..exceptions import AuthCanceled, AuthUnknownError
 class WeixinOAuth2(BaseOAuth2):
     """Weixin OAuth authentication backend"""
     name = 'weixin'
-    ID_KEY = 'openid'
+    ID_KEY = 'unionid'
     AUTHORIZATION_URL = 'https://open.weixin.qq.com/connect/qrconnect'
     ACCESS_TOKEN_URL = 'https://api.weixin.qq.com/sns/oauth2/access_token'
     ACCESS_TOKEN_METHOD = 'POST'
@@ -40,7 +40,7 @@ class WeixinOAuth2(BaseOAuth2):
     def user_data(self, access_token, *args, **kwargs):
         data = self.get_json('https://api.weixin.qq.com/sns/userinfo', params={
             'access_token': access_token,
-            'openid': kwargs['response']['openid']
+            'openid': kwargs.get('response', {}).get('openid') or kwargs.get('openid', 'null')
         })
         nickname = data.get('nickname')
         if nickname:


### PR DESCRIPTION
These changes are to adapt to the WeChat login on the mobile phone.
1. Change ID_KEY from ‘ openid’ to ‘ unionid’.

> If the developer has multiple mobile apps, web apps, and public accounts (including applets), the unionid can be used to distinguish the uniqueness of the user.

2. When the user_data method is called, the openid get method is added. This allows you to pass in the openid when you manually call the do_auth method. 